### PR TITLE
Madhav/app 126 add microsoft login support to pwi auth package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ PwiAuth is a Flutter package that provides authentication functionalities for th
 
 - **Email and Password Authentication**
 - **Google Sign-In Authentication**
+- **Microsoft Sign-In Authentication**
 - **Session Management with Custom Tokens**
 - **Password Reset Functionality**
 - **Authentication State Changes Stream**
@@ -55,7 +56,8 @@ flutter pub get
 ## Prerequisites
 
 - **Firebase Project**: You need a Firebase project configured for your Flutter application.
-- **Firebase Authentication**: Enable Email/Password and Google Sign-In methods in your Firebase console.
+- **Firebase Authentication**: Enable Email/Password, Google Sign-In, and Microsoft methods in your Firebase console.
+- **Microsoft Entra ID Setup**: Configure a Microsoft OAuth application (client ID/secret and redirect URI) for Firebase Microsoft provider.
 - **Backend Endpoint**: A backend server endpoint that handles session cookies and authentication status (`_endPoint`).
 
 ## Setup
@@ -68,7 +70,7 @@ Follow the official Firebase documentation to add Firebase to your Flutter app:
 
 ### 2. Configure Firebase Authentication
 
-- Enable **Email/Password** and **Google Sign-In** in your [Firebase console](https://console.firebase.google.com/).
+- Enable **Email/Password**, **Google Sign-In**, and **Microsoft** in your [Firebase console](https://console.firebase.google.com/).
 
 ### 3. Set Up Backend Endpoints
 
@@ -141,6 +143,12 @@ if (pwiAuth.signedIn) {
   print('No user is signed in');
 }
 ```
+
+### Sign In with Microsoft
+
+```dart
+await pwiAuth.signInWithMicrosoft();
+```
 ---
 
 ## Methods
@@ -152,6 +160,8 @@ if (pwiAuth.signedIn) {
 - **`Future<void> signUp({required String email, required String password, required String firstName, required String lastName})`**: Creates a new user account.
 
 - **`Future<void> signInWithGoogle()`**: Signs in a user using Google authentication.
+
+- **`Future<void> signInWithMicrosoft()`**: Signs in a user using Microsoft authentication.
 
 - **`Future<void> signOut()`**: Signs out the current user and clears the session cookie.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ flutter pub get
 
 - **Firebase Project**: You need a Firebase project configured for your Flutter application.
 - **Firebase Authentication**: Enable Email/Password, Google Sign-In, and Microsoft methods in your Firebase console.
-- **Microsoft Entra ID Setup**: Configure a Microsoft OAuth application (client ID/secret and redirect URI) for Firebase Microsoft provider.
 - **Backend Endpoint**: A backend server endpoint that handles session cookies and authentication status (`_endPoint`).
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -143,11 +143,6 @@ if (pwiAuth.signedIn) {
 }
 ```
 
-### Sign In with Microsoft
-
-```dart
-await pwiAuth.signInWithMicrosoft();
-```
 ---
 
 ## Methods

--- a/example/lib/mock_pwi_auth.dart
+++ b/example/lib/mock_pwi_auth.dart
@@ -93,6 +93,9 @@ class MockPwiAuth extends PwiAuthBase {
   Future<void> signInWithGoogle() async => setSignedIn(value: true);
 
   @override
+  Future<void> signInWithMicrosoft() async => setSignedIn(value: true);
+
+  @override
   Future<void> signUp({
     required String email,
     required String password,

--- a/lib/data/models/employee.dart
+++ b/lib/data/models/employee.dart
@@ -104,7 +104,6 @@ class Employee {
       }
       return defaultValue; // Return default value if key is missing or value is null
     }
-    
 
     return Employee._(
       id: doc.id,

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -3,6 +3,7 @@ library pwi_auth;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_login/flutter_login.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:pwi_auth/pwi_auth.dart';
 
 class LoginPage extends StatelessWidget {
@@ -53,6 +54,15 @@ class LoginPage extends StatelessWidget {
     }
   }
 
+  Future<String?> _signInWithMicrosoft() async {
+    try {
+      await auth.signInWithMicrosoft();
+      return null;
+    } catch (e) {
+      return e.toString();
+    }
+  }
+
   Future<String?> _recoverPassword(String email) async {
     try {
       await auth.sendPasswordResetEmail(email);
@@ -64,7 +74,7 @@ class LoginPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final showGoogleLogin = Uri.base.host.contains('pwiworks.app') ||
+    final showSocialLogin = Uri.base.host.contains('pwiworks.app') ||
         Uri.base.host.contains('localhost');
 
     return FlutterLogin(
@@ -85,13 +95,25 @@ class LoginPage extends StatelessWidget {
             'If you already have an account with us, we\'ll send you an email to reset your password.',
         providersTitleFirst: "or",
       ),
-      loginProviders: showGoogleLogin
+      theme: LoginTheme(
+        providerButtonPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      ),
+      loginProviders: showSocialLogin
           ? <LoginProvider>[
               LoginProvider(
-                button: Buttons.google,
-                label: 'Sign in with Google',
+                icon: FontAwesomeIcons.google,
+                label: 'Google',
                 callback: () async {
                   await _signInWithGoogle();
+                  return;
+                },
+              ),
+              LoginProvider(
+                icon: FontAwesomeIcons.microsoft,
+                label: 'Microsoft',
+                callback: () async {
+                  await _signInWithMicrosoft();
                   return;
                 },
               ),

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -19,13 +19,19 @@ class LoginPage extends StatelessWidget {
     required this.auth,
   });
 
-  Future<String?> _signInWithCredentials(LoginData data) async {
+  Future<String?> _runAuthAction(Future<void> Function() action) async {
     try {
-      await auth.signIn(email: data.name, password: data.password);
+      await action();
       return null;
     } catch (e) {
       return e.toString();
     }
+  }
+
+  Future<String?> _signInWithCredentials(LoginData data) async {
+    return _runAuthAction(
+      () => auth.signIn(email: data.name, password: data.password),
+    );
   }
 
   Future<String?> _signUp(SignupData data) async {
@@ -33,43 +39,25 @@ class LoginPage extends StatelessWidget {
       return Future.value('Invalid username or password');
     }
 
-    try {
-      await auth.signUp(
+    return _runAuthAction(
+      () => auth.signUp(
           email: data.name!,
           password: data.password!,
           firstName: data.additionalSignupData?["firstName"] ?? "Unknown",
-          lastName: data.additionalSignupData?["lastName"] ?? "Unknown");
-      return null;
-    } catch (e) {
-      return e.toString();
-    }
+          lastName: data.additionalSignupData?["lastName"] ?? "Unknown"),
+    );
   }
 
   Future<String?> _signInWithGoogle() async {
-    try {
-      await auth.signInWithGoogle();
-      return null;
-    } catch (e) {
-      return e.toString();
-    }
+    return _runAuthAction(auth.signInWithGoogle);
   }
 
   Future<String?> _signInWithMicrosoft() async {
-    try {
-      await auth.signInWithMicrosoft();
-      return null;
-    } catch (e) {
-      return e.toString();
-    }
+    return _runAuthAction(auth.signInWithMicrosoft);
   }
 
   Future<String?> _recoverPassword(String email) async {
-    try {
-      await auth.sendPasswordResetEmail(email);
-      return null;
-    } catch (e) {
-      return e.toString();
-    }
+    return _runAuthAction(() => auth.sendPasswordResetEmail(email));
   }
 
   @override

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -92,18 +92,12 @@ class LoginPage extends StatelessWidget {
               LoginProvider(
                 icon: FontAwesomeIcons.google,
                 label: 'Google',
-                callback: () async {
-                  await _signInWithGoogle();
-                  return;
-                },
+                callback: () => _signInWithGoogle(),
               ),
               LoginProvider(
                 icon: FontAwesomeIcons.microsoft,
                 label: 'Microsoft',
-                callback: () async {
-                  await _signInWithMicrosoft();
-                  return;
-                },
+                callback: () => _signInWithMicrosoft(),
               ),
             ]
           : [],

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -43,20 +43,18 @@ class PwiAuth extends PwiAuthBase {
 
   /// Indicates if native Firebase Auth should be used (disables custom streaming/session logic)
   final bool appUsesFirebaseAuth;
-  final String? microsoftTenant;
 
   /// Private constructor
   PwiAuth._({
     bool loggingEnabled = false,
     this.appUsesFirebaseAuth = false,
-    this.microsoftTenant,
   }) : useSessionCookie = !appUsesFirebaseAuth &&
             !kDebugMode &&
             kIsWeb &&
             Uri.base.host.contains('pwiworks.app') {
     enableLogs = loggingEnabled;
     log(
-      'PwiAuth created with useSessionCookie = useSessionCookie, appUsesFirebaseAuth = $appUsesFirebaseAuth, microsoftTenant = $microsoftTenant',
+      'PwiAuth created with useSessionCookie = useSessionCookie, appUsesFirebaseAuth = $appUsesFirebaseAuth',
     );
     if (!appUsesFirebaseAuth) {
       _subscribeToAuthChanges();
@@ -78,18 +76,18 @@ class PwiAuth extends PwiAuthBase {
   factory PwiAuth({
     bool loggingEnabled = false,
     bool appUsesFirebaseAuth = false,
-    String? microsoftTenant,
   }) {
     _instance ??= PwiAuth._(
       loggingEnabled: loggingEnabled,
       appUsesFirebaseAuth: appUsesFirebaseAuth,
-      microsoftTenant: microsoftTenant,
     );
     return _instance!;
   }
 
   // #endregion
   static const String _notSignedInMessage = "not-signed-in";
+  static const String _microsoftTenantId =
+      '731a5963-b7c3-4d2c-8081-d10e4b63077d';
 
   // Private variables
   final String _endPoint = 'auth.pwiworks.app';
@@ -387,13 +385,7 @@ class PwiAuth extends PwiAuthBase {
     if (!_hasPendingMicrosoftLink || user == null) return;
 
     try {
-      final provider = OAuthProvider('microsoft.com');
-      final tenant = microsoftTenant?.trim();
-      if (tenant != null && tenant.isNotEmpty) {
-        provider.setCustomParameters({'tenant': tenant});
-      }
-
-      await user.linkWithPopup(provider);
+      await user.linkWithPopup(_createMicrosoftProvider());
       _hasPendingMicrosoftLink = false;
 
       await user.reload();
@@ -408,6 +400,11 @@ class PwiAuth extends PwiAuthBase {
         'Failed to link pending Microsoft provider: ${e.code}: ${e.message}',
       );
     }
+  }
+
+  OAuthProvider _createMicrosoftProvider() {
+    return OAuthProvider('microsoft.com')
+      ..setCustomParameters({'tenant': _microsoftTenantId});
   }
 
   /// Signs in a user using Google authentication.
@@ -434,12 +431,7 @@ class PwiAuth extends PwiAuthBase {
   /// Throws an [Exception] if sign-in fails.
   @override
   Future<void> signInWithMicrosoft() async {
-    final provider = OAuthProvider('microsoft.com');
-    final tenant = microsoftTenant?.trim();
-    if (tenant != null && tenant.isNotEmpty) {
-      provider.setCustomParameters({'tenant': tenant});
-      log('Using Microsoft tenant override: $tenant');
-    }
+    final provider = _createMicrosoftProvider();
 
     try {
       final userCredential = await _auth.signInWithPopup(provider);

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -43,17 +43,21 @@ class PwiAuth extends PwiAuthBase {
 
   /// Indicates if native Firebase Auth should be used (disables custom streaming/session logic)
   final bool appUsesFirebaseAuth;
+  final String? microsoftTenant;
 
   /// Private constructor
   PwiAuth._({
     bool loggingEnabled = false,
     this.appUsesFirebaseAuth = false,
+    this.microsoftTenant,
   }) : useSessionCookie = !appUsesFirebaseAuth &&
             !kDebugMode &&
             kIsWeb &&
             Uri.base.host.contains('pwiworks.app') {
     enableLogs = loggingEnabled;
-    log('PwiAuth created with useSessionCookie = useSessionCookie, appUsesFirebaseAuth = $appUsesFirebaseAuth');
+    log(
+      'PwiAuth created with useSessionCookie = useSessionCookie, appUsesFirebaseAuth = $appUsesFirebaseAuth, microsoftTenant = $microsoftTenant',
+    );
     if (!appUsesFirebaseAuth) {
       _subscribeToAuthChanges();
       if (useSessionCookie) {
@@ -74,10 +78,12 @@ class PwiAuth extends PwiAuthBase {
   factory PwiAuth({
     bool loggingEnabled = false,
     bool appUsesFirebaseAuth = false,
+    String? microsoftTenant,
   }) {
     _instance ??= PwiAuth._(
       loggingEnabled: loggingEnabled,
       appUsesFirebaseAuth: appUsesFirebaseAuth,
+      microsoftTenant: microsoftTenant,
     );
     return _instance!;
   }
@@ -347,18 +353,60 @@ class PwiAuth extends PwiAuthBase {
     }
   }
 
-  Future<void> _signInWithProvider(
-      AuthProvider provider, String errorMessage) async {
-    try {
-      final userCredential = await _auth.signInWithPopup(provider);
-      if (!appUsesFirebaseAuth && useSessionCookie) {
-        final idToken = await userCredential.user?.getIdToken(true);
-        await _setSessionCookie(idToken!);
-      }
-    } catch (e) {
-      log(e.toString());
-      throw errorMessage;
+  Future<void> _handleAccountExistsWithDifferentCredential({
+    required FirebaseAuthException error,
+    required AuthProvider attemptedProvider,
+  }) async {
+    final pendingCredential = error.credential;
+    final email = error.email;
+
+    if (pendingCredential == null || email == null || email.trim().isEmpty) {
+      throw 'An account already exists with this email but could not be linked automatically. '
+          'Please sign in using your existing method first, then try Microsoft again.';
     }
+
+    final normalizedEmail = email.trim().toLowerCase();
+    log('Account collision for $normalizedEmail. Attempting automatic linking.');
+
+    try {
+      final existingAccount = await _auth.signInWithPopup(GoogleAuthProvider());
+      final currentUser = existingAccount.user;
+      final matchedEmail = currentUser?.email?.trim().toLowerCase();
+      if (currentUser == null || matchedEmail != normalizedEmail) {
+        if (_auth.currentUser != null) {
+          await _auth.signOut();
+        }
+        throw 'Google sign-in returned a different account than the one being linked.';
+      }
+
+      try {
+        await currentUser.linkWithCredential(pendingCredential);
+        log('Linked pending credential to existing Google account.');
+      } on FirebaseAuthException catch (linkError) {
+        if (linkError.code == 'invalid-credential-or-provider-id') {
+          log(
+            'linkWithCredential failed for ${attemptedProvider.providerId}; retrying with linkWithPopup.',
+          );
+          await currentUser.linkWithPopup(attemptedProvider);
+          log('Linked provider using linkWithPopup fallback.');
+        } else {
+          rethrow;
+        }
+      }
+
+      if (!appUsesFirebaseAuth && useSessionCookie) {
+        final idToken = await currentUser.getIdToken(true);
+        if (idToken != null) {
+          await _setSessionCookie(idToken);
+        }
+      }
+      return;
+    } on FirebaseAuthException catch (e) {
+      log('Automatic Google linking failed: ${e.code}: ${e.message}');
+    }
+
+    throw 'An account for $normalizedEmail already exists with a different sign-in method. '
+        'Sign in with your existing method first, then link Microsoft from your account.';
   }
 
   /// Signs in a user using Google authentication.
@@ -366,10 +414,17 @@ class PwiAuth extends PwiAuthBase {
   /// Throws an [Exception] if sign-in fails.
   @override
   Future<void> signInWithGoogle() async {
-    await _signInWithProvider(
-      GoogleAuthProvider(),
-      "Error signing in with Google. Try again later",
-    );
+    try {
+      final provider = GoogleAuthProvider();
+      final userCredential = await _auth.signInWithPopup(provider);
+      if (!appUsesFirebaseAuth && useSessionCookie) {
+        final idToken = await userCredential.user?.getIdToken(true);
+        await _setSessionCookie(idToken!);
+      }
+    } catch (e) {
+      log(e.toString());
+      throw "Error signing in with Google. Try again later";
+    }
   }
 
   /// Signs in a user using Microsoft authentication.
@@ -377,10 +432,33 @@ class PwiAuth extends PwiAuthBase {
   /// Throws an [Exception] if sign-in fails.
   @override
   Future<void> signInWithMicrosoft() async {
-    await _signInWithProvider(
-      OAuthProvider('microsoft.com'),
-      "Error signing in with Microsoft. Try again later",
-    );
+    final provider = OAuthProvider('microsoft.com');
+    final tenant = microsoftTenant?.trim();
+    if (tenant != null && tenant.isNotEmpty) {
+      provider.setCustomParameters({'tenant': tenant});
+      log('Using Microsoft tenant override: $tenant');
+    }
+
+    try {
+      final userCredential = await _auth.signInWithPopup(provider);
+      if (!appUsesFirebaseAuth && useSessionCookie) {
+        final idToken = await userCredential.user?.getIdToken(true);
+        await _setSessionCookie(idToken!);
+      }
+    } on FirebaseAuthException catch (e) {
+      if (e.code == 'account-exists-with-different-credential') {
+        await _handleAccountExistsWithDifferentCredential(
+          error: e,
+          attemptedProvider: provider,
+        );
+        return;
+      }
+      log('${e.code}: ${e.message}');
+      throw "Error signing in with Microsoft. Try again later";
+    } catch (e) {
+      log(e.toString());
+      throw "Error signing in with Microsoft. Try again later";
+    }
   }
 
   /// Creates a new user account with the given [email], [password], [firstName], and [lastName].

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -24,6 +24,7 @@ abstract class PwiAuthBase {
   Future<void> signOut();
   Future<void> signIn({required String email, required String password});
   Future<void> signInWithGoogle();
+  Future<void> signInWithMicrosoft();
   Future<void> signUp({
     required String email,
     required String password,
@@ -361,6 +362,24 @@ class PwiAuth extends PwiAuthBase {
     } catch (e) {
       log(e.toString());
       throw "Error signing in with Google. Try again later";
+    }
+  }
+
+  /// Signs in a user using Microsoft authentication.
+  ///
+  /// Throws an [Exception] if sign-in fails.
+  @override
+  Future<void> signInWithMicrosoft() async {
+    try {
+      final provider = OAuthProvider('microsoft.com');
+      final userCredential = await _auth.signInWithPopup(provider);
+      if (!appUsesFirebaseAuth && useSessionCookie) {
+        final idToken = await userCredential.user?.getIdToken(true);
+        await _setSessionCookie(idToken!);
+      }
+    } catch (e) {
+      log(e.toString());
+      throw "Error signing in with Microsoft. Try again later";
     }
   }
 

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -347,13 +347,9 @@ class PwiAuth extends PwiAuthBase {
     }
   }
 
-  /// Signs in a user using Google authentication.
-  ///
-  /// Throws an [Exception] if sign-in fails.
-  @override
-  Future<void> signInWithGoogle() async {
+  Future<void> _signInWithProvider(
+      AuthProvider provider, String errorMessage) async {
     try {
-      final provider = GoogleAuthProvider();
       final userCredential = await _auth.signInWithPopup(provider);
       if (!appUsesFirebaseAuth && useSessionCookie) {
         final idToken = await userCredential.user?.getIdToken(true);
@@ -361,8 +357,19 @@ class PwiAuth extends PwiAuthBase {
       }
     } catch (e) {
       log(e.toString());
-      throw "Error signing in with Google. Try again later";
+      throw errorMessage;
     }
+  }
+
+  /// Signs in a user using Google authentication.
+  ///
+  /// Throws an [Exception] if sign-in fails.
+  @override
+  Future<void> signInWithGoogle() async {
+    await _signInWithProvider(
+      GoogleAuthProvider(),
+      "Error signing in with Google. Try again later",
+    );
   }
 
   /// Signs in a user using Microsoft authentication.
@@ -370,17 +377,10 @@ class PwiAuth extends PwiAuthBase {
   /// Throws an [Exception] if sign-in fails.
   @override
   Future<void> signInWithMicrosoft() async {
-    try {
-      final provider = OAuthProvider('microsoft.com');
-      final userCredential = await _auth.signInWithPopup(provider);
-      if (!appUsesFirebaseAuth && useSessionCookie) {
-        final idToken = await userCredential.user?.getIdToken(true);
-        await _setSessionCookie(idToken!);
-      }
-    } catch (e) {
-      log(e.toString());
-      throw "Error signing in with Microsoft. Try again later";
-    }
+    await _signInWithProvider(
+      OAuthProvider('microsoft.com'),
+      "Error signing in with Microsoft. Try again later",
+    );
   }
 
   /// Creates a new user account with the given [email], [password], [firstName], and [lastName].

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -117,6 +117,7 @@ class PwiAuth extends PwiAuthBase {
   bool get authStatusChecked => _authStatusChecked;
   static bool _forceCheckingAuth = false;
   bool _isSigningIn = false;
+  bool _hasPendingMicrosoftLink = false;
 
   /// Forces a check of the authentication status by attempting to sign in with a session cookie.
   ///
@@ -283,6 +284,7 @@ class PwiAuth extends PwiAuthBase {
   /// Signs out the current user and clears the session cookie.
   @override
   Future<void> signOut() async {
+    _hasPendingMicrosoftLink = false;
     if (appUsesFirebaseAuth) {
       await _auth.signOut();
       return;
@@ -331,6 +333,7 @@ class PwiAuth extends PwiAuthBase {
     try {
       final userCredential = await _auth.signInWithEmailAndPassword(
           email: email, password: password);
+      await _updatePendingMicrosoftCredentialLink(userCredential.user);
       if (!appUsesFirebaseAuth && useSessionCookie) {
         final idToken = await userCredential.user?.getIdToken(true);
         await _setSessionCookie(idToken!);
@@ -355,8 +358,11 @@ class PwiAuth extends PwiAuthBase {
 
   Future<void> _handleAccountExistsWithDifferentCredential({
     required FirebaseAuthException error,
-    required AuthProvider attemptedProvider,
   }) async {
+    log(
+      'Microsoft collision received: code=${error.code}, email=${error.email}, '
+      'hasCredential=${error.credential != null}',
+    );
     final pendingCredential = error.credential;
     final email = error.email;
 
@@ -366,47 +372,42 @@ class PwiAuth extends PwiAuthBase {
     }
 
     final normalizedEmail = email.trim().toLowerCase();
-    log('Account collision for $normalizedEmail. Attempting automatic linking.');
+    log('Account collision for $normalizedEmail.');
+
+    _hasPendingMicrosoftLink = true;
+
+    throw 'This email ($normalizedEmail) is already registered. '
+        'Please sign in with your existing email and password, or with Google. '
+        'Microsoft will be linked to your account automatically.';
+  }
+
+  /// Links a pending Microsoft credential to the current signed-in [user].
+  /// No-op if no pending credential exists or [user] is null.
+  Future<void> _updatePendingMicrosoftCredentialLink(User? user) async {
+    if (!_hasPendingMicrosoftLink || user == null) return;
 
     try {
-      final existingAccount = await _auth.signInWithPopup(GoogleAuthProvider());
-      final currentUser = existingAccount.user;
-      final matchedEmail = currentUser?.email?.trim().toLowerCase();
-      if (currentUser == null || matchedEmail != normalizedEmail) {
-        if (_auth.currentUser != null) {
-          await _auth.signOut();
-        }
-        throw 'Google sign-in returned a different account than the one being linked.';
+      final provider = OAuthProvider('microsoft.com');
+      final tenant = microsoftTenant?.trim();
+      if (tenant != null && tenant.isNotEmpty) {
+        provider.setCustomParameters({'tenant': tenant});
       }
 
-      try {
-        await currentUser.linkWithCredential(pendingCredential);
-        log('Linked pending credential to existing Google account.');
-      } on FirebaseAuthException catch (linkError) {
-        if (linkError.code == 'invalid-credential-or-provider-id') {
-          log(
-            'linkWithCredential failed for ${attemptedProvider.providerId}; retrying with linkWithPopup.',
-          );
-          await currentUser.linkWithPopup(attemptedProvider);
-          log('Linked provider using linkWithPopup fallback.');
-        } else {
-          rethrow;
-        }
-      }
+      await user.linkWithPopup(provider);
+      _hasPendingMicrosoftLink = false;
 
-      if (!appUsesFirebaseAuth && useSessionCookie) {
-        final idToken = await currentUser.getIdToken(true);
-        if (idToken != null) {
-          await _setSessionCookie(idToken);
-        }
-      }
-      return;
+      await user.reload();
     } on FirebaseAuthException catch (e) {
-      log('Automatic Google linking failed: ${e.code}: ${e.message}');
-    }
+      if (e.code == 'provider-already-linked' ||
+          e.code == 'credential-already-in-use') {
+        _hasPendingMicrosoftLink = false;
+        return;
+      }
 
-    throw 'An account for $normalizedEmail already exists with a different sign-in method. '
-        'Sign in with your existing method first, then link Microsoft from your account.';
+      log(
+        'Failed to link pending Microsoft provider: ${e.code}: ${e.message}',
+      );
+    }
   }
 
   /// Signs in a user using Google authentication.
@@ -417,6 +418,7 @@ class PwiAuth extends PwiAuthBase {
     try {
       final provider = GoogleAuthProvider();
       final userCredential = await _auth.signInWithPopup(provider);
+      await _updatePendingMicrosoftCredentialLink(userCredential.user);
       if (!appUsesFirebaseAuth && useSessionCookie) {
         final idToken = await userCredential.user?.getIdToken(true);
         await _setSessionCookie(idToken!);
@@ -447,10 +449,7 @@ class PwiAuth extends PwiAuthBase {
       }
     } on FirebaseAuthException catch (e) {
       if (e.code == 'account-exists-with-different-credential') {
-        await _handleAccountExistsWithDifferentCredential(
-          error: e,
-          attemptedProvider: provider,
-        );
+        await _handleAccountExistsWithDifferentCredential(error: e);
         return;
       }
       log('${e.code}: ${e.message}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   url_launcher: ^6.3.1
   mvvm_plus: ^1.5.4
   flutter_login: ^6.0.0
+  font_awesome_flutter: ^10.0.0
   flex_color_scheme: ^8.0.2
   flutter_layout_grid: ^2.0.8
   rounded_loading_button_plus: ^3.0.1


### PR DESCRIPTION
1. Adds Microsoft sign-in support using Firebase Auth.
2. Exposes signInWithMicrosoft() through PwiAuthBase and PwiAuth.
3. Wires Microsoft login into the existing login page.
4. Updates mock auth and README documentation.
5. Switches social login UI to icon-style providers for better spacing during migration.