### PR TITLE
Madhav/app 246 remove sign in with google and backend autolinking for Microsoft in pwi auth package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ PwiAuth is a Flutter package that provides authentication functionalities for th
 ## Features
 
 - **Email and Password Authentication**
-- **Google Sign-In Authentication**
 - **Microsoft Sign-In Authentication**
 - **Session Management with Custom Tokens**
 - **Password Reset Functionality**
@@ -56,7 +55,7 @@ flutter pub get
 ## Prerequisites
 
 - **Firebase Project**: You need a Firebase project configured for your Flutter application.
-- **Firebase Authentication**: Enable Email/Password, Google Sign-In, and Microsoft methods in your Firebase console.
+- **Firebase Authentication**: Enable Email/Password and Microsoft methods in your Firebase console.
 - **Backend Endpoint**: A backend server endpoint that handles session cookies and authentication status (`_endPoint`).
 
 ## Setup
@@ -69,7 +68,7 @@ Follow the official Firebase documentation to add Firebase to your Flutter app:
 
 ### 2. Configure Firebase Authentication
 
-- Enable **Email/Password**, **Google Sign-In**, and **Microsoft** in your [Firebase console](https://console.firebase.google.com/).
+- Enable **Email/Password** and **Microsoft** in your [Firebase console](https://console.firebase.google.com/).
 
 ### 3. Set Up Backend Endpoints
 
@@ -152,8 +151,6 @@ if (pwiAuth.signedIn) {
 - **`Future<void> signIn({required String email, required String password})`**: Signs in a user with email and password.
 
 - **`Future<void> signUp({required String email, required String password, required String firstName, required String lastName})`**: Creates a new user account.
-
-- **`Future<void> signInWithGoogle()`**: Signs in a user using Google authentication.
 
 - **`Future<void> signInWithMicrosoft()`**: Signs in a user using Microsoft authentication.
 

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -3,7 +3,6 @@ library pwi_auth;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_login/flutter_login.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:pwi_auth/pwi_auth.dart';
 
 class LoginPage extends StatelessWidget {
@@ -86,8 +85,8 @@ class LoginPage extends StatelessWidget {
       loginProviders: showSocialLogin
           ? <LoginProvider>[
               LoginProvider(
-                icon: FontAwesomeIcons.microsoft,
-                label: 'Microsoft',
+                button: Buttons.microsoft,
+                label: 'Sign in with Microsoft',
                 callback: () => _signInWithMicrosoft(),
               ),
             ]

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -48,10 +48,6 @@ class LoginPage extends StatelessWidget {
     );
   }
 
-  Future<String?> _signInWithGoogle() async {
-    return _runAuthAction(auth.signInWithGoogle);
-  }
-
   Future<String?> _signInWithMicrosoft() async {
     return _runAuthAction(auth.signInWithMicrosoft);
   }
@@ -89,11 +85,6 @@ class LoginPage extends StatelessWidget {
       ),
       loginProviders: showSocialLogin
           ? <LoginProvider>[
-              LoginProvider(
-                icon: FontAwesomeIcons.google,
-                label: 'Google',
-                callback: () => _signInWithGoogle(),
-              ),
               LoginProvider(
                 icon: FontAwesomeIcons.microsoft,
                 label: 'Microsoft',

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -375,7 +375,7 @@ class PwiAuth extends PwiAuthBase {
     _hasPendingMicrosoftLink = true;
 
     throw 'This email ($normalizedEmail) is already registered. '
-        'Please sign in with your existing email and password, or with Google. '
+        'Please sign in with your existing email and password. '
         'Microsoft will be linked to your account automatically.';
   }
 

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -115,7 +115,6 @@ class PwiAuth extends PwiAuthBase {
   bool get authStatusChecked => _authStatusChecked;
   static bool _forceCheckingAuth = false;
   bool _isSigningIn = false;
-  bool _hasPendingMicrosoftLink = false;
 
   /// Forces a check of the authentication status by attempting to sign in with a session cookie.
   ///
@@ -282,7 +281,6 @@ class PwiAuth extends PwiAuthBase {
   /// Signs out the current user and clears the session cookie.
   @override
   Future<void> signOut() async {
-    _hasPendingMicrosoftLink = false;
     if (appUsesFirebaseAuth) {
       await _auth.signOut();
       return;
@@ -308,7 +306,6 @@ class PwiAuth extends PwiAuthBase {
   ///
   /// Throws an [Exception] if setting the session cookie fails.
   Future<void> _setSessionCookie(String idToken) async {
-    if (appUsesFirebaseAuth) return;
     final client = BrowserClient()..withCredentials = true;
 
     final url = Uri.parse('https://$_endPoint/api/set-session-cookie');
@@ -322,6 +319,41 @@ class PwiAuth extends PwiAuthBase {
     }
   }
 
+  Future<void> _setSessionCookieForUser(User? user) async {
+    if (appUsesFirebaseAuth || !useSessionCookie) return;
+
+    final idToken = await user?.getIdToken(true);
+    if (idToken == null) {
+      throw Exception('missing-id-token');
+    }
+
+    await _setSessionCookie(idToken);
+  }
+
+  Future<String> _fetchMicrosoftAutoLinkCustomToken(
+      String microsoftIdToken) async {
+    final client = BrowserClient()..withCredentials = true;
+
+    final url = Uri.parse('https://$_endPoint/api/microsoft-auto-link');
+    final headers = {'Content-Type': 'application/json'};
+    final body = jsonEncode({'microsoftIdToken': microsoftIdToken});
+
+    final response = await client.post(url, headers: headers, body: body);
+
+    if (response.statusCode != 200) {
+      throw Exception('microsoft-auto-link-failed');
+    }
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    final customToken = responseBody['customToken'] as String?;
+
+    if (customToken == null || customToken.isEmpty) {
+      throw Exception('microsoft-auto-link-missing-custom-token');
+    }
+
+    return customToken;
+  }
+
   /// Signs in a user with the given [email] and [password].
   ///
   /// Throws an [Exception] if sign-in fails.
@@ -331,11 +363,7 @@ class PwiAuth extends PwiAuthBase {
     try {
       final userCredential = await _auth.signInWithEmailAndPassword(
           email: email, password: password);
-      await _updatePendingMicrosoftCredentialLink(userCredential.user);
-      if (!appUsesFirebaseAuth && useSessionCookie) {
-        final idToken = await userCredential.user?.getIdToken(true);
-        await _setSessionCookie(idToken!);
-      }
+      await _setSessionCookieForUser(userCredential.user);
     } catch (e) {
       final error = e.toString();
       log(error);
@@ -354,51 +382,31 @@ class PwiAuth extends PwiAuthBase {
     }
   }
 
-  Future<void> _handleAccountExistsWithDifferentCredential({
+  Future<void> _handleMicrosoftCollision({
     required FirebaseAuthException error,
   }) async {
-    log(
-      'Microsoft collision received: code=${error.code}, email=${error.email}, '
-      'hasCredential=${error.credential != null}',
-    );
-    final pendingCredential = error.credential;
-    final email = error.email;
+    final credential = error.credential;
+    final oAuthCredential = credential is OAuthCredential ? credential : null;
+    final microsoftIdToken = oAuthCredential?.idToken;
+    final normalizedEmail = error.email?.trim().toLowerCase();
 
-    if (pendingCredential == null || email == null || email.trim().isEmpty) {
-      throw 'An account already exists with this email but could not be linked automatically. '
-          'Please sign in using your existing method first, then try Microsoft again.';
-    }
-
-    final normalizedEmail = email.trim().toLowerCase();
-    log('Account collision for $normalizedEmail.');
-
-    _hasPendingMicrosoftLink = true;
-
-    throw 'This email ($normalizedEmail) is already registered. '
-        'Please sign in with your existing email and password.';
-  }
-
-  /// Links a pending Microsoft credential to the current signed-in [user].
-  /// No-op if no pending credential exists or [user] is null.
-  Future<void> _updatePendingMicrosoftCredentialLink(User? user) async {
-    if (!_hasPendingMicrosoftLink || user == null) return;
-
-    try {
-      await user.linkWithPopup(_createMicrosoftProvider());
-      _hasPendingMicrosoftLink = false;
-
-      await user.reload();
-    } on FirebaseAuthException catch (e) {
-      if (e.code == 'provider-already-linked' ||
-          e.code == 'credential-already-in-use') {
-        _hasPendingMicrosoftLink = false;
+    if (microsoftIdToken != null && microsoftIdToken.isNotEmpty) {
+      try {
+        final customToken =
+            await _fetchMicrosoftAutoLinkCustomToken(microsoftIdToken);
+        final userCredential = await _auth.signInWithCustomToken(customToken);
+        await _setSessionCookieForUser(userCredential.user);
         return;
+      } catch (autoLinkError) {
+        log('Microsoft auto-link failed: $autoLinkError');
       }
-
-      log(
-        'Failed to link pending Microsoft provider: ${e.code}: ${e.message}',
-      );
     }
+
+    if (normalizedEmail == null || normalizedEmail.isEmpty) {
+      throw 'We could not complete Microsoft sign-in for this account. Please sign in with your existing email and password.';
+    }
+
+    throw 'We could not complete Microsoft sign-in for $normalizedEmail. Please sign in with your existing email and password.';
   }
 
   OAuthProvider _createMicrosoftProvider() {
@@ -414,11 +422,7 @@ class PwiAuth extends PwiAuthBase {
     try {
       final provider = GoogleAuthProvider();
       final userCredential = await _auth.signInWithPopup(provider);
-      await _updatePendingMicrosoftCredentialLink(userCredential.user);
-      if (!appUsesFirebaseAuth && useSessionCookie) {
-        final idToken = await userCredential.user?.getIdToken(true);
-        await _setSessionCookie(idToken!);
-      }
+      await _setSessionCookieForUser(userCredential.user);
     } catch (e) {
       log(e.toString());
       throw "Error signing in with Google. Try again later";
@@ -434,13 +438,10 @@ class PwiAuth extends PwiAuthBase {
 
     try {
       final userCredential = await _auth.signInWithPopup(provider);
-      if (!appUsesFirebaseAuth && useSessionCookie) {
-        final idToken = await userCredential.user?.getIdToken(true);
-        await _setSessionCookie(idToken!);
-      }
+      await _setSessionCookieForUser(userCredential.user);
     } on FirebaseAuthException catch (e) {
       if (e.code == 'account-exists-with-different-credential') {
-        await _handleAccountExistsWithDifferentCredential(error: e);
+        await _handleMicrosoftCollision(error: e);
         return;
       }
       log('${e.code}: ${e.message}');
@@ -470,10 +471,7 @@ class PwiAuth extends PwiAuthBase {
         throw "error-creating-user";
       }
       await credential.user!.updateDisplayName("$firstName $lastName");
-      if (!appUsesFirebaseAuth && useSessionCookie) {
-        final idToken = await credential.user?.getIdToken(true);
-        await _setSessionCookie(idToken!);
-      }
+      await _setSessionCookieForUser(credential.user);
     } catch (e) {
       log(e.toString());
       final error = e.toString();

--- a/lib/pwi_auth.dart
+++ b/lib/pwi_auth.dart
@@ -375,8 +375,7 @@ class PwiAuth extends PwiAuthBase {
     _hasPendingMicrosoftLink = true;
 
     throw 'This email ($normalizedEmail) is already registered. '
-        'Please sign in with your existing email and password. '
-        'Microsoft will be linked to your account automatically.';
+        'Please sign in with your existing email and password.';
   }
 
   /// Links a pending Microsoft credential to the current signed-in [user].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   url_launcher: ^6.3.1
   mvvm_plus: ^1.5.4
   flutter_login: ^6.0.0
-  font_awesome_flutter: ^10.0.0
   flex_color_scheme: ^8.0.2
   flutter_layout_grid: ^2.0.8
   rounded_loading_button_plus: ^3.0.1


### PR DESCRIPTION
- Remove the login-page Google helper _signInWithGoogle().
- Remove the visible Google provider button from loginProviders.
- Update the account-conflict message to Please sign in with your existing email and password.
- Using autolink api for Microsoft accounts in the backend.