### PR TITLE
Madhav/app 565 add support contact workflow to pwi auth flutter errorscreen

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,6 +91,9 @@ class ErrorPageScreen extends StatelessWidget {
       body: ErrorScreen(
         message:
             "This is an error screen. It uses animations to draw attention.",
+        supportEmailAddress: 'support@example.com',
+        supportEmailSubject: 'Example error',
+        supportEmailBody: 'Example error details.',
       ),
     );
   }

--- a/lib/widgets/error_screen.dart
+++ b/lib/widgets/error_screen.dart
@@ -50,6 +50,11 @@ class ErrorScreen extends StatelessWidget {
                 bottomWidget: supportEmailAddress != null &&
                         supportEmailAddress!.isNotEmpty
                     ? FilledButton.icon(
+                        style: FilledButton.styleFrom(
+                          backgroundColor:
+                              Theme.of(context).colorScheme.onError,
+                          foregroundColor: Theme.of(context).colorScheme.error,
+                        ),
                         onPressed: _emailSupport,
                         icon: const Icon(Icons.email_outlined),
                         label: Text(supportButtonLabel),

--- a/lib/widgets/error_screen.dart
+++ b/lib/widgets/error_screen.dart
@@ -64,9 +64,13 @@ class ErrorScreen extends StatelessWidget {
   }
 
   Future<void> _emailSupport() {
+    if (supportEmailAddress?.isEmpty ?? true) {
+      return Future.value();
+    }
+
     final uri = Uri(
       scheme: 'mailto',
-      path: supportEmailAddress,
+      path: supportEmailAddress!,
       queryParameters: {
         if (supportEmailSubject != null) 'subject': supportEmailSubject,
         if (supportEmailBody != null) 'body': supportEmailBody,

--- a/lib/widgets/error_screen.dart
+++ b/lib/widgets/error_screen.dart
@@ -52,8 +52,9 @@ class ErrorScreen extends StatelessWidget {
                     ? FilledButton.icon(
                         style: FilledButton.styleFrom(
                           backgroundColor:
-                              Theme.of(context).colorScheme.onError,
-                          foregroundColor: Theme.of(context).colorScheme.error,
+                              Theme.of(context).colorScheme.errorContainer,
+                          foregroundColor:
+                              Theme.of(context).colorScheme.onErrorContainer,
                         ),
                         onPressed: _emailSupport,
                         icon: const Icon(Icons.email_outlined),

--- a/lib/widgets/error_screen.dart
+++ b/lib/widgets/error_screen.dart
@@ -8,13 +8,13 @@ class ErrorScreen extends StatelessWidget {
   final String message;
 
   /// Email address used by the support contact button.
-  final String supportEmailAddress;
+  final String? supportEmailAddress;
 
   /// Subject line used by the support contact button.
-  final String supportEmailSubject;
+  final String? supportEmailSubject;
 
   /// Body used by the support contact button.
-  final String supportEmailBody;
+  final String? supportEmailBody;
 
   /// Label shown on the support contact button.
   final String supportButtonLabel;
@@ -25,9 +25,9 @@ class ErrorScreen extends StatelessWidget {
   const ErrorScreen({
     super.key,
     required this.message,
-    required this.supportEmailAddress,
-    required this.supportEmailSubject,
-    required this.supportEmailBody,
+    this.supportEmailAddress,
+    this.supportEmailSubject,
+    this.supportEmailBody,
     this.supportButtonLabel = 'Email Support',
   });
 
@@ -47,11 +47,14 @@ class ErrorScreen extends StatelessWidget {
               child: InfoCard(
                 message: message,
                 displayType: InfoCardDisplayType.error,
-                bottomWidget: FilledButton.icon(
-                  onPressed: _emailSupport,
-                  icon: const Icon(Icons.email_outlined),
-                  label: Text(supportButtonLabel),
-                ),
+                bottomWidget: supportEmailAddress != null &&
+                        supportEmailAddress!.isNotEmpty
+                    ? FilledButton.icon(
+                        onPressed: _emailSupport,
+                        icon: const Icon(Icons.email_outlined),
+                        label: Text(supportButtonLabel),
+                      )
+                    : null,
               ),
             ),
           ),
@@ -61,10 +64,13 @@ class ErrorScreen extends StatelessWidget {
   }
 
   Future<void> _emailSupport() {
-    final uri = Uri.parse(
-      'mailto:$supportEmailAddress'
-      '?subject=${Uri.encodeComponent(supportEmailSubject)}'
-      '&body=${Uri.encodeComponent(supportEmailBody)}',
+    final uri = Uri(
+      scheme: 'mailto',
+      path: supportEmailAddress,
+      queryParameters: {
+        if (supportEmailSubject != null) 'subject': supportEmailSubject,
+        if (supportEmailBody != null) 'body': supportEmailBody,
+      },
     );
 
     return launchUrl(uri);

--- a/lib/widgets/error_screen.dart
+++ b/lib/widgets/error_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'info_card.dart';
 
 /// A stateless widget that displays an error message on the screen.
@@ -6,10 +7,29 @@ class ErrorScreen extends StatelessWidget {
   /// The error message to be displayed.
   final String message;
 
+  /// Email address used by the support contact button.
+  final String supportEmailAddress;
+
+  /// Subject line used by the support contact button.
+  final String supportEmailSubject;
+
+  /// Body used by the support contact button.
+  final String supportEmailBody;
+
+  /// Label shown on the support contact button.
+  final String supportButtonLabel;
+
   /// Creates an [ErrorScreen] widget.
   ///
   /// The [message] parameter is required and must not be null.
-  const ErrorScreen({super.key, required this.message});
+  const ErrorScreen({
+    super.key,
+    required this.message,
+    required this.supportEmailAddress,
+    required this.supportEmailSubject,
+    required this.supportEmailBody,
+    this.supportButtonLabel = 'Email Support',
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -27,11 +47,26 @@ class ErrorScreen extends StatelessWidget {
               child: InfoCard(
                 message: message,
                 displayType: InfoCardDisplayType.error,
+                bottomWidget: FilledButton.icon(
+                  onPressed: _emailSupport,
+                  icon: const Icon(Icons.email_outlined),
+                  label: Text(supportButtonLabel),
+                ),
               ),
             ),
           ),
         ),
       ),
     );
+  }
+
+  Future<void> _emailSupport() {
+    final uri = Uri.parse(
+      'mailto:$supportEmailAddress'
+      '?subject=${Uri.encodeComponent(supportEmailSubject)}'
+      '&body=${Uri.encodeComponent(supportEmailBody)}',
+    );
+
+    return launchUrl(uri);
   }
 }

--- a/lib/widgets/error_screen.dart
+++ b/lib/widgets/error_screen.dart
@@ -71,10 +71,12 @@ class ErrorScreen extends StatelessWidget {
     final uri = Uri(
       scheme: 'mailto',
       path: supportEmailAddress!,
-      queryParameters: {
-        if (supportEmailSubject != null) 'subject': supportEmailSubject,
-        if (supportEmailBody != null) 'body': supportEmailBody,
-      },
+      query: [
+        if (supportEmailSubject != null)
+          'subject=${Uri.encodeComponent(supportEmailSubject!)}',
+        if (supportEmailBody != null)
+          'body=${Uri.encodeComponent(supportEmailBody!)}',
+      ].join('&'),
     );
 
     await launchUrl(uri);

--- a/lib/widgets/error_screen.dart
+++ b/lib/widgets/error_screen.dart
@@ -63,9 +63,9 @@ class ErrorScreen extends StatelessWidget {
     );
   }
 
-  Future<void> _emailSupport() {
+  Future<void> _emailSupport() async {
     if (supportEmailAddress?.isEmpty ?? true) {
-      return Future.value();
+      return;
     }
 
     final uri = Uri(
@@ -77,6 +77,6 @@ class ErrorScreen extends StatelessWidget {
       },
     );
 
-    return launchUrl(uri);
+    await launchUrl(uri);
   }
 }

--- a/lib/widgets/info_card.dart
+++ b/lib/widgets/info_card.dart
@@ -119,7 +119,7 @@ class InfoCard extends StatelessWidget {
               ],
             ),
             if (bottomWidget != null) ...[
-              const SizedBox(height: 12),
+              const SizedBox(height: 8),
               SizedBox(
                 width: double.infinity,
                 child: Align(

--- a/lib/widgets/info_card.dart
+++ b/lib/widgets/info_card.dart
@@ -58,6 +58,9 @@ class InfoCard extends StatelessWidget {
   /// Optional widget displayed below the main message row.
   final Widget? bottomWidget;
 
+  /// Alignment for [bottomWidget] within the card width.
+  final AlignmentGeometry bottomWidgetAlignment;
+
   /// Creates an [InfoCard] widget.
   ///
   /// Provide either [message] or [richTextMessage]. The [useStandardCardMargin] parameter defaults
@@ -73,6 +76,7 @@ class InfoCard extends StatelessWidget {
     this.icon,
     this.trailingWidget,
     this.bottomWidget,
+    this.bottomWidgetAlignment = Alignment.center,
   }) : assert(
           message != null || richTextMessage != null,
           'Provide either message or richTextMessage.',
@@ -116,7 +120,13 @@ class InfoCard extends StatelessWidget {
             ),
             if (bottomWidget != null) ...[
               const SizedBox(height: 12),
-              bottomWidget!,
+              SizedBox(
+                width: double.infinity,
+                child: Align(
+                  alignment: bottomWidgetAlignment,
+                  child: bottomWidget!,
+                ),
+              ),
             ],
           ],
         ),

--- a/lib/widgets/info_card.dart
+++ b/lib/widgets/info_card.dart
@@ -52,6 +52,12 @@ class InfoCard extends StatelessWidget {
   /// Optional override for icon to display alongside the message.
   final Icon? icon;
 
+  /// Optional widget displayed after the message in the main row.
+  final Widget? trailingWidget;
+
+  /// Optional widget displayed below the main message row.
+  final Widget? bottomWidget;
+
   /// Creates an [InfoCard] widget.
   ///
   /// Provide either [message] or [richTextMessage]. The [useStandardCardMargin] parameter defaults
@@ -65,6 +71,8 @@ class InfoCard extends StatelessWidget {
     this.useStandardCardMargin = false,
     this.displayType = InfoCardDisplayType.normal,
     this.icon,
+    this.trailingWidget,
+    this.bottomWidget,
   }) : assert(
           message != null || richTextMessage != null,
           'Provide either message or richTextMessage.',
@@ -80,23 +88,36 @@ class InfoCard extends StatelessWidget {
       color: _getBackgroundColor(context),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(_icon, color: textColor),
-            const SizedBox(width: 8),
-            Flexible(
-              child: richTextMessage != null
-                  ? Text.rich(
-                      richTextMessage!,
-                      style: TextStyle(
-                        color: textColor,
-                        decorationColor: textColor,
-                      ),
-                    )
-                  : Text(message!, style: TextStyle(color: textColor)),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Icon(_icon, color: textColor),
+                const SizedBox(width: 8),
+                Flexible(
+                  child: richTextMessage != null
+                      ? Text.rich(
+                          richTextMessage!,
+                          style: TextStyle(
+                            color: textColor,
+                            decorationColor: textColor,
+                          ),
+                        )
+                      : Text(message!, style: TextStyle(color: textColor)),
+                ),
+                if (trailingWidget != null) ...[
+                  const SizedBox(width: 8),
+                  trailingWidget!,
+                ],
+              ],
             ),
+            if (bottomWidget != null) ...[
+              const SizedBox(height: 12),
+              bottomWidget!,
+            ],
           ],
         ),
       ),


### PR DESCRIPTION
- Adds support email action to `ErrorScreen`.
- Opens a prefilled `mailto:` link with support address, subject, and body.
- Adds optional custom button label for the support action.
- Extends `InfoCard` with optional trailing and bottom widget slots.
- Updates the example app to show the new `ErrorScreen` support email API.